### PR TITLE
just use the literal symbols instead of hex

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,10 +13,8 @@ Object.defineProperty(exports, '__esModule', {
 exports['default'] = stripquotes;
 
 function stripquotes(q) {
-  // ' " ‘ “ ‹ «
-  var quoteStart = '"|\'|‘|“|‹|«';
-  // ' " ’ ” › »
-  var quoteEnd = '"|\'|’|”|›|»|';
+  var quoteStart = '\'|"|‘|“|‹|«'; // \u0022|\u0027|\u2018|\u201C|\u2039|\u00AB
+  var quoteEnd = '\'|"|’|”|›|»'; // \u0022|\u0027|\u2019|\u201D|\u203A|\u00BB
 
   if (typeof q !== 'string') {
     throw new Error('input was \'' + typeof q + '\' and not of type \'string\'');

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,8 @@
  * @return {String} s
  */
 export default function stripquotes(q) {
-  // ' " ‘ “ ‹ «
-  const quoteStart = `\u0022|\u0027|\u2018|\u201C|\u2039|\u00AB`
-  // ' " ’ ” › »
-  const quoteEnd   = `\u0022|\u0027|\u2019|\u201D|\u203A|\u00BB|`
+  const quoteStart = `'|"|‘|“|‹|«` // \u0022|\u0027|\u2018|\u201C|\u2039|\u00AB
+  const quoteEnd   = `'|"|’|”|›|»` // \u0022|\u0027|\u2019|\u201D|\u203A|\u00BB
 
   if (typeof q !== 'string') {
     throw new Error(`input was '${typeof q}' and not of type 'string'`)

--- a/test.js
+++ b/test.js
@@ -84,3 +84,9 @@ test('can remove unbalanced quotations from a string', function (t) {
   t.equal(stripquotes('‘cheese crackers”'), 'cheese crackers')
   t.end()
 })
+
+test('will return the given string without modification', function (t) {
+  t.plan(1)
+  t.equal(stripquotes('cheese crackers'), 'cheese crackers')
+  t.end()
+})


### PR DESCRIPTION
# notes

this also fixes an issue where a normal string _without_ being surrounded by quotes, results in breakage
